### PR TITLE
feat: add configurable action with supported kick and read-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,5 @@ LOGGING_LEVEL=INFO
 # - READONLY: Make the user read-only
 ACTION=KICK
 # The number of days to keep the group read-only, valid only if ACTION is READONLY
+# must be a positive integer between 1 and 350
 READONLY_DAYS=7

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 TELEGRAM_BOT_TOKEN=your_bot_token
 GROUP_CHAT_ID=your_group_chat_id
 LOGGING_LEVEL=INFO
+# Supported actions:
+# - KICK: Kick the user from the group
+# - READONLY: Make the user read-only
+ACTION=KICK
+# The number of days to keep the group read-only, valid only if ACTION is READONLY
+READONLY_DAYS=7

--- a/.pylintrc
+++ b/.pylintrc
@@ -155,7 +155,7 @@ class-attribute-naming-style=any
 #class-attribute-rgx=
 
 # Naming style matching correct class constant names.
-class-const-naming-style=UPPER_CASE
+class-const-naming-style=any
 
 # Regular expression matching correct class constant names. Overrides class-
 # const-naming-style. If left empty, class constant names will be checked with

--- a/README.md
+++ b/README.md
@@ -2,24 +2,25 @@
 
 The name of this Telegram antispam bot is inspired by Cerberus from Greek mythology. It can also be referred to as Cerbuś.
 
-This repository contains a Telegram bot configured to monitor a specific group chat. The bot reads all messages, checks for keywords, deletes messages containing those keywords, and bans the user who sent them.
+This repository contains a Telegram bot configured to monitor a specific group chat. The bot reads all messages, checks for keywords, deletes messages containing those keywords, and bans the users who sent them.
 
 Messages from the chat admin are unfiltered.
 
 ## Features
 
-- Reads messages from a specific group chat
-- Deletes messages containing keywords from a list
-- Bans users who send messages with keywords
-- Unfiltered messages from chat admins
-- Configurable via environment variables
-- Deployed using Docker
+- Reads messages from a specific group chat.
+- Deletes messages containing keywords from a list.
+- Bans users who send messages with keywords.
+- Allows unfiltered messages from chat admins.
+- Configurable via environment variables.
+- Deployable using Docker.
 
 ## Prerequisites
 
 - Docker
 - Telegram bot token
 - Group chat ID
+- Bot must have admin privileges in the chat
 
 ## Setup
 
@@ -36,6 +37,8 @@ Messages from the chat admin are unfiltered.
     TELEGRAM_BOT_TOKEN=your_telegram_bot_token
     GROUP_CHAT_ID=your_group_chat_id
     ```
+
+   Optionally, you can configure the action (kick or read-only) and log level. Refer to the `.env.example` file for an example.
 
 3. Create a `keywords.yaml` file with the following content:
 
@@ -82,10 +85,10 @@ Messages from the chat admin are unfiltered.
 
 ## TODO
 
-- Add configurable quarantine (e.g., set read-only mode for a configurable period)
-- Improve bot configuration
-- Move the keyword list from the YAML file to a more appropriate location
-- Enhance CI/CD pipeline
+- Add configurable quarantine (e.g., set read-only mode for a configurable period).
+- Improve bot configuration.
+- Move the keyword list from the YAML file to a more appropriate location.
+- Enhance the CI/CD pipeline.
 
 ## Contributing
 

--- a/src/cerberek/main.py
+++ b/src/cerberek/main.py
@@ -31,7 +31,7 @@ action = os.getenv('ACTION', 'kick').lower()
 if action not in ['kick', 'readonly']:
     logger.warning("Invalid action: %s. Defaulting to 'kick'.", action)
     action = 'kick'
-if action == 'radonly':
+if action == 'readonly':
     logger.warning("Action set to 'readonly'. Users will not be kicked, but messages will be deleted.")
     readonly_days = os.getenv('READONLY_DAYS', '7')
     try:

--- a/src/cerberek/main.py
+++ b/src/cerberek/main.py
@@ -27,6 +27,20 @@ token = os.getenv('TELEGRAM_BOT_TOKEN')
 group_chat_id = os.getenv('GROUP_CHAT_ID')
 logging_level = os.getenv('LOGGING_LEVEL', 'INFO').upper()
 logger.info("Telegram Bot Token: <censored>, Group Chat ID: %s, Loggin level %s", group_chat_id, logging_level)
+action = os.getenv('ACTION', 'kick').lower()
+if action not in ['kick', 'readonly']:
+    logger.warning("Invalid action: %s. Defaulting to 'kick'.", action)
+    action = 'kick'
+if action == 'radonly':
+    logger.warning("Action set to 'readonly'. Users will not be kicked, but messages will be deleted.")
+    readonly_days = os.getenv('READONLY_DAYS', '7')
+    try:
+        readonly_days = int(readonly_days)
+        if readonly_days < 1:
+            raise ValueError("READONLY_DAYS must be a positive integer.")
+    except ValueError:
+        logger.warning("Invalid READONLY_DAYS value: %s. Defaulting to 7 days.", readonly_days)
+        readonly_days = 7
 
 # Set logging level
 if logging_level in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
@@ -124,16 +138,45 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
             except Exception as e:  # pylint: disable=W0718
                 logger.error("Failed to delete message: %s", e)
 
-            try:
-                # Kick the user
-                await context.bot.ban_chat_member(chat_id=from_chat_id, user_id=from_user_id, revoke_messages=True)
-                logger.info(
-                    "User %s kicked for using keyword: %s",
-                    from_username,
-                    keyword,
-                )
-            except Exception as e:  # pylint: disable=W0718
-                logger.error("Failed to kick user: %s", e)
+            if action == 'readonly':
+                try:
+                    # Restrict the user to read-only mode
+                    await context.bot.restrict_chat_member(
+                        chat_id=from_chat_id,
+                        user_id=from_user_id,
+                        permissions={
+                            'can_send_messages': False,
+                            'can_send_media_messages': False,
+                            'can_send_polls': False,
+                            'can_send_other_messages': False,
+                            'can_add_web_page_previews': False,
+                            'can_invite_users': False,
+                            'can_pin_messages': False,
+                        },
+                        until_date=readonly_days * 24 * 60 * 60,  # Restrict for the specified number of days
+                    )
+                    logger.info(
+                        "User %s restricted to read-only mode for %d days due to keyword: %s",
+                        from_username,
+                        readonly_days,
+                        keyword,
+                    )
+                except Exception as e:
+                    logger.error("Failed to restrict user: %s", e)
+                    return
+
+            elif action == 'kick':
+
+                try:
+                    # Kick the user
+                    await context.bot.ban_chat_member(chat_id=from_chat_id, user_id=from_user_id, revoke_messages=True)
+                    logger.info(
+                        "User %s kicked for using keyword: %s",
+                        from_username,
+                        keyword,
+                    )
+                except Exception as e:  # pylint: disable=W0718
+                    logger.error("Failed to kick user: %s", e)
 
 
 def main():


### PR DESCRIPTION
This pull request introduces a new feature to the Cerberek, allowing configurable user actions (kick or read-only mode) when a keyword violation is detected. It also updates the documentation and improves bot configuration options.

### New Feature: Configurable User Actions
* Added support for two actions: `KICK` (default) and `READONLY`. The `READONLY` action restricts users to read-only mode for a configurable number of days. This is configurable via the `ACTION` and `READONLY_DAYS` environment variables in `.env.example`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR4-R9) [[2]](diffhunk://#diff-613773c8ac9bf9bcdae109c2878b8fc89ddc168a807caefc9bdf3b03f9973987R30-R43)
* Implemented logic in `src/cerberek/main.py` to handle the `READONLY` action, including restricting user permissions and logging the action.

### Documentation Updates
* Updated `README.md` to reflect the new `ACTION` and `READONLY_DAYS` configuration options, ensuring users are aware of the bot's capabilities and setup requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R41-R42)
* Enhanced the `TODO` section in `README.md` with clearer formatting and updated tasks.